### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://fortude.visualstudio.com/aa2796b6-fa24-4f55-a638-9126a38c6cde/da3a7fef-6531-46a1-a243-d16feb1f56e5/_apis/work/boardbadge/549c7657-775d-4537-9aa9-4feb1dbf04c7)](https://fortude.visualstudio.com/aa2796b6-fa24-4f55-a638-9126a38c6cde/_boards/board/t/da3a7fef-6531-46a1-a243-d16feb1f56e5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1107](https://fortude.visualstudio.com/aa2796b6-fa24-4f55-a638-9126a38c6cde/_workitems/edit/1107). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.